### PR TITLE
install bundler:1.17.2 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.4.3
   - 2.5.0
 install:
-  - gem install bundler
+  - gem install bundler:1.17.2
   - bundle install
 script:
   - bundle exec rake spec


### PR DESCRIPTION
Builds in travis were failing due to the version of `bundler` being different to that specified in `Gemfile.lock`

This PR specifies a specific version of bundler (`1.17.2`) so that the same version is always installed 